### PR TITLE
Fix gu binary name in matrix strategy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ jobs:
         gu-binary: [gu, gu.cmd]
         exclude:
           - os: ubuntu-latest
-            gu-binary: gu.cmd
-          - os: macos-latest
-            gu-binary: gu.cmd
-          - os: windows-latest
             gu-binary: gu
+          - os: macos-latest
+            gu-binary: gu
+          - os: windows-latest
+            gu-binary: gu.cmd
     steps:
       - name: Setup Graalvm
         id: setup-graalvm


### PR DESCRIPTION
This PR changes the name for the gu binaries in the matrix strategy example. At least for macOS the binary is `gu`, I guess that for linux it's the same and for windows `gu.cmd`.