### PR TITLE
fix: Correct gu command for windows vs others

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ jobs:
         gu-binary: [gu, gu.cmd]
         exclude:
           - os: ubuntu-latest
-            gu-binary: gu.cmd
-          - os: macos-latest
-            gu-binary: gu.cmd
-          - os: windows-latest
             gu-binary: gu
+          - os: macos-latest
+            gu-binary: gu
+          - os: windows-latest
+            gu-binary: gu.cmd
     steps:
       - name: Setup Graalvm
         id: setup-graalvm


### PR DESCRIPTION
It looks like this was the wrong way around in the code example.